### PR TITLE
build-specs.sh: add set -e

### DIFF
--- a/helpers/build-specs.sh
+++ b/helpers/build-specs.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Build multiple rpm specs, after installing the build dependencies
 
+set -e # exit on helper error
+
 helpers=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 specs=()


### PR DESCRIPTION
Add `set -e` to build-specs.sh so that we exit when one of the helpers
fails, which happens when python3 is not installed.