### PR TITLE
RPM build caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-tmp
+/tmp
+/cache
 *.pyc
 *.tmp
 .DS_Store

--- a/helpers/build-specs.sh
+++ b/helpers/build-specs.sh
@@ -18,6 +18,33 @@ if [ "${#specs[@]}" = "0" ]; then
     exit 0
 fi
 
+# Used for caching rpms between builds
+rpm_file_root=/root/rpmbuild/RPMS/
+function rpm_file_list {
+    find "$rpm_file_root" -type f | sed "s|$rpm_file_root||"
+}
+function file_hash {
+    local spec="$1"
+    local n=$(basename "$spec" .spec)
+    local h=$(sha1sum "$1" | cut -d' ' -f1)
+    echo "$n.$h"
+}
+function check_cache {
+    local spec="$1"
+    local h=$(file_hash "$spec")
+    if [ -f "/cache/old/$h.tar" ]; then
+        echo "* FOUND IN CACHE: $spec"
+        tar -C "$rpm_file_root" -xvf "/cache/old/$h.tar"
+        return 0
+    fi
+    return 1
+}
+cache=
+if [ ! -z "$BUILDER_CACHE" ] && [ ! -z "$BUILDER_CACHE_THIS" ]; then
+    cache=1
+    mkdir -p /cache/new
+fi
+
 # Parse the specfiles to evaluate conditionals for builddeps, and store them in tempfiles
 # Also check for specs we need to skip (BUILDER_SKIP)
 tmpdir=$(mktemp -d /tmp/build-specs.parsed.XXXXXX)
@@ -26,6 +53,12 @@ declare -A skip_specs # associative array (dict)
 if [ -x /usr/bin/rpmspec ]; then
     # RHEL >= 7 has this tool
     for spec in "${specs[@]}"; do
+        # First check if we have the rpms cached
+        if [ "$cache" = "1" ] && check_cache "$spec"; then
+            skip_specs["$spec"]=1
+            continue
+        fi
+
         name=$(basename "$spec")
         tmpfile="$tmpdir/$name"
         rpmspec -P "$spec" > "$tmpfile"
@@ -35,12 +68,19 @@ if [ -x /usr/bin/rpmspec ]; then
             rm -f "$tmpfile"
         fi
     done
+    touch "$tmpdir/__empty.spec" # To prevent an error because of an empty dir
     reqs=`$helpers/buildrequires-from-specs $tmpdir/*.spec`
 else
     # For RHEL 6 let's just try to install all we find
     # You can add 'BUILDER_EL6_SKIP' somewhere in the spec to skip it (comment is ok for this one)
     reqs=`$helpers/buildrequires-from-specs "${specs[@]}"`
     for spec in "${specs[@]}"; do
+        # First check if we have the rpms cached
+        if [ "$cache" = "1" ] && check_cache "$spec"; then
+            skip_specs["$spec"]=1
+            continue
+        fi
+
         if grep --silent 'BUILDER_EL6_SKIP' "$spec"; then
             echo "BUILDER_EL6_SKIP: $spec will be skipped"
             skip_specs["$spec"]=1
@@ -60,10 +100,20 @@ for spec in "${specs[@]}"; do
     if [ -z "${skip_specs[$spec]}" ]; then
         # Download sources
         spectool -g -R "$spec"
-        # Build the rpm
+        
+        # Build the rpm and record which files are new
+        rpm_file_list > /tmp/rpms-before
         rpmbuild --define "_sdistdir /sdist" -ba "$spec"
+        rpm_file_list > /tmp/rpms-after
+
+        diff /tmp/rpms-before /tmp/rpms-after | grep '^> ' | sed 's/^> /NEW: /'
+        if [ "$cache" = "1" ]; then
+            new_rpms=$(diff /tmp/rpms-before /tmp/rpms-after | grep '^> ' | sed 's/^> //')
+            h=$(file_hash "$spec")
+            tar -C "$rpm_file_root" -cvf "/cache/new/$h.tar" $new_rpms 
+        fi
     else
-        echo "Skipping spec (BUILDER_SKIP)"
+        echo "Skipping spec (BUILDER_SKIP or in cache)"
     fi
 done
 


### PR DESCRIPTION
A new `-c` option will enable rpm build caching per spec. This is
currently only suitable for vendor packages, because it determines
changes by the hash of the spec file only

This mechanism can be extended later to specs that depend on source
packages by hashing their contents.

To use this, you need to add the following to your RPM build
Dockerfiles:

    @IF [ ! -z "$BUILDER_CACHE" ]
    @EVAL ADD builder/cache/${BUILDER_TARGET}/ /cache/old/
    ENV BUILDER_CACHE 1
    @ENDIF

and set `BUILDER_CACHE_THIS=1` on the build-specs.sh lines where
you want to enable this.