### PR TITLE
Create package version when using pre-releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+# Skip any installation
+install: true
+
+script:
+  - ./tests/test_versioning.sh

--- a/gen-version
+++ b/gen-version
@@ -5,9 +5,9 @@ DIRTY=""
 git status | grep -q clean || DIRTY='.dirty'
 
 # Special environment variable to signal that we are building a release, as this
-# has condequenses for the version number.
+# has consequenses for the version number.
 if [ "${IS_RELEASE}" = "YES" ]; then
-  TAG="$(git describe --tags --exact-match 2> /dev/null | cut -d- -f 2-)"
+  TAG="$(git describe --tags --exact-match 2> /dev/null)"
   if [ -n "${TAG}" ]; then
     # We're on a tag
     echo "${TAG}${DIRTY}" > .version
@@ -22,28 +22,59 @@ fi
 # Generate the version number based on the branch
 #
 if [ ! -z "$(git rev-parse --abbrev-ref HEAD 2> /dev/null)" ]; then
-  GIT_VERSION="$(git describe --tags 2> /dev/null)"
-  LAST_TAG="$(echo ${GIT_VERSION} | cut -d- -f1)"
-  COMMITS_SINCE_TAG="$(echo ${GIT_VERSION} | cut -d- -f2)"
-  GIT_HASH="$(echo ${GIT_VERSION} | cut -d- -f3)"
+  # Possible `git describe --tags` outputs:
+  # 2.4.1 (when on a tag)
+  # 2.4.1-alpha1 (when on a tag)
+  # 2.4.2-1-gdad05a9 (not on a tag)
+  # 2.4.2-alpha1-1-gdad05a9 (not on a tag)
 
-  if [ -z "${GIT_VERSION}" ]; then
-    LAST_TAG=0.0.0
-    COMMITS_SINCE_TAG="$(git log --oneline | wc -l)"
-    GIT_HASH="$(git rev-parse HEAD | cut -c1-10 2> /dev/null)"
+  OIFS=$IFS
+  IFS='-' GIT_VERSION=( $(git describe --tags 2> /dev/null) )
+  IFS=$OIFS
+  LAST_TAG="${GIT_VERSION[0]}"
+  COMMITS_SINCE_TAG=''
+  GIT_HASH=''
+
+  if [ ${#GIT_VERSION[@]} -eq 1 ]; then
+    # We're on a tag, but IS_RELEASE was unset
+    COMMITS_SINCE_TAG=0
   fi
 
-  BRANCH=".$(git rev-parse --abbrev-ref HEAD | perl -p -e 's/[^[:alnum:]]//g;')"
-  [ "${BRANCH}" = ".master" ] && BRANCH=''
+  if [ ${#GIT_VERSION[@]} -eq 2 ]; then
+    # On a tag for a pre-release, e.g. 1.2.3-beta2
+    LAST_TAG="${LAST_TAG}-${GIT_VERSION[1]}"
+    COMMITS_SINCE_TAG=0
+  fi
 
-  TAG="$(git describe --tags --exact-match 2> /dev/null | cut -d- -f 2-)"
-  if [ -n "${TAG}" ]; then # We're exactly on a tag
-    COMMITS_SINCE_TAG="0"
+  if [ ${#GIT_VERSION[@]} -eq 3 ]; then
+    # Not on a tag
+    # 1.2.3-100-g123456
+    COMMITS_SINCE_TAG="${GIT_VERSION[1]}"
+    GIT_HASH="${GIT_VERSION[2]}"
+  fi
+
+  if [ ${#GIT_VERSION[@]} -eq 4 ]; then
+    # Not on a tag, but a pre-release was made before
+    # 1.2.3-rc1-100-g123456
+    LAST_TAG="${LAST_TAG}-${GIT_VERSION[1]}"
+    COMMITS_SINCE_TAG="${GIT_VERSION[1]}"
+    GIT_HASH="${GIT_VERSION[2]}"
+  fi
+
+  if [ -z "${GIT_HASH}" ]; then
     GIT_HASH="g$(git show --no-patch --format=format:%h HEAD 2>/dev/null)"
     if [ -z "$GIT_HASH" ]; then
       GIT_HASH="g$(git show --format=format:%h HEAD | head -n1)"
     fi
   fi
+
+  if [ -z "${LAST_TAG}" ]; then
+    LAST_TAG=0.0.0
+    COMMITS_SINCE_TAG="$(git log --oneline | wc -l)"
+  fi
+
+  BRANCH=".$(git rev-parse --abbrev-ref HEAD | perl -p -e 's/[^[:alnum:]]//g;')"
+  [ "${BRANCH}" = ".master" ] && BRANCH=''
 
   VERSION="${LAST_TAG}.${COMMITS_SINCE_TAG}${BRANCH}.${GIT_HASH}${DIRTY}"
 fi

--- a/helpers/build-debs.sh
+++ b/helpers/build-debs.sh
@@ -50,6 +50,25 @@ for dir in "${dirs[@]}"; do
     echo 'Unable to determine distribution codename!'
     exit 1
   fi
+  OIFS=$IFS
+  IFS='-' version_elems=($BUILDER_VERSION)
+  IFS=$OIFS
+  if [ ${#version_elems[@]} -gt 1 ]; then
+    # There's a dash in the version number, indicating a pre-release
+    # e.g. 1.2.3-alpha1.100.gaff36b2
+    # which would be split in 1.2.3 and alpha1.100.gaff36b2
+    OIFS=$IFS
+    IFS='.' sub_version_elems=(${version_elems[1]})
+    IFS=$OIFS
+    # sub_version_elems would now be alpha1 100 and gaff36b2
+    BUILDER_VERSION="${version_elems[0]}~${sub_version_elems[0]}"
+    release="0.${sub_version_elems[1]}.${sub_version_elems[2]}"
+    if [ ${#sub_version_elems[@]} -eq 4 ]; then
+      # Branch is in there as well
+      release="${release}.${sub_version_elems[3]}"
+    fi
+    BUILDER_RELEASE="${release}.${BUILDER_RELEASE}"
+  fi
   cat > debian/changelog << EOF
 $sourcename (${BUILDER_VERSION}-${BUILDER_RELEASE}.${distro_release}) unstable; urgency=medium
 

--- a/helpers/build-debs.sh
+++ b/helpers/build-debs.sh
@@ -54,7 +54,7 @@ for dir in "${dirs[@]}"; do
   fi
   set_debian_versions
   cat > debian/changelog << EOF
-$sourcename (${BUILDER_VERSION}-${BUILDER_RELEASE}.${distro_release}) unstable; urgency=medium
+$sourcename (${BUILDER_DEB_VERSION}-${BUILDER_DEB_RELEASE}.${distro_release}) unstable; urgency=medium
 
   * Automatic build
 

--- a/helpers/build-debs.sh
+++ b/helpers/build-debs.sh
@@ -4,6 +4,8 @@
 
 helpers=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
+source "$helpers/functions.sh"
+
 dirs=()
 for dir in "$@"; do
   # If BUILDER_PACKAGE_MATCH is set, only build the packages that match, otherwise build all
@@ -50,25 +52,7 @@ for dir in "${dirs[@]}"; do
     echo 'Unable to determine distribution codename!'
     exit 1
   fi
-  OIFS=$IFS
-  IFS='-' version_elems=($BUILDER_VERSION)
-  IFS=$OIFS
-  if [ ${#version_elems[@]} -gt 1 ]; then
-    # There's a dash in the version number, indicating a pre-release
-    # e.g. 1.2.3-alpha1.100.gaff36b2
-    # which would be split in 1.2.3 and alpha1.100.gaff36b2
-    OIFS=$IFS
-    IFS='.' sub_version_elems=(${version_elems[1]})
-    IFS=$OIFS
-    # sub_version_elems would now be alpha1 100 and gaff36b2
-    BUILDER_VERSION="${version_elems[0]}~${sub_version_elems[0]}"
-    release="0.${sub_version_elems[1]}.${sub_version_elems[2]}"
-    if [ ${#sub_version_elems[@]} -eq 4 ]; then
-      # Branch is in there as well
-      release="${release}.${sub_version_elems[3]}"
-    fi
-    BUILDER_RELEASE="${release}.${BUILDER_RELEASE}"
-  fi
+  set_debian_versions
   cat > debian/changelog << EOF
 $sourcename (${BUILDER_VERSION}-${BUILDER_RELEASE}.${distro_release}) unstable; urgency=medium
 

--- a/helpers/build-rocks.sh
+++ b/helpers/build-rocks.sh
@@ -53,7 +53,7 @@ fi
 
 set -e
 
-version=`echo "${BUILDER_VERSION:-0.0.0}" | sed 's/[+]/./'`
+version=`echo "${BUILDER_VERSION:-0.0.0}" | sed 's/[-+]/./'`
 
 build_dir=builder/tmp
 [ ! -d "$build_dir" ] && mkdir "$build_dir"

--- a/helpers/build-specs.sh
+++ b/helpers/build-specs.sh
@@ -5,6 +5,8 @@ set -e # exit on helper error
 
 helpers=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
+source "$helpers/functions.sh"
+
 specs=()
 for spec in "$@"; do
     # If BUILDER_PACKAGE_MATCH is set, only build the specs that match, otherwise build all
@@ -46,17 +48,7 @@ if [ ! -z "$BUILDER_CACHE" ] && [ ! -z "$BUILDER_CACHE_THIS" ]; then
 fi
 
 export SRC_VERSION=$BUILDER_VERSION
-OIFS=$IFS
-IFS='-' version_elems=($BUILDER_VERSION)
-IFS=$OIFS
-if [ ${#version_elems[@]} -gt 1 ]; then
-  # There's a dash in the version number, indicating a pre-release
-  # e.g. 1.2.3-alpha1.100.gaff36b2
-  # which would be split in 1.2.3 and alpha1.100.gaff36b2
-  BUILDER_VERSION=${version_elems[0]}
-  BUILDER_RELEASE="0.${version_elems[1]}.${BUILDER_RELEASE}"
-fi
-
+set_rpm_versions
 # Parse the specfiles to evaluate conditionals for builddeps, and store them in tempfiles
 # Also check for specs we need to skip (BUILDER_SKIP)
 tmpdir=$(mktemp -d /tmp/build-specs.parsed.XXXXXX)

--- a/helpers/build-specs.sh
+++ b/helpers/build-specs.sh
@@ -47,7 +47,6 @@ if [ ! -z "$BUILDER_CACHE" ] && [ ! -z "$BUILDER_CACHE_THIS" ]; then
     mkdir -p /cache/new
 fi
 
-export SRC_VERSION=$BUILDER_VERSION
 set_rpm_versions
 # Parse the specfiles to evaluate conditionals for builddeps, and store them in tempfiles
 # Also check for specs we need to skip (BUILDER_SKIP)

--- a/helpers/build-specs.sh
+++ b/helpers/build-specs.sh
@@ -45,6 +45,18 @@ if [ ! -z "$BUILDER_CACHE" ] && [ ! -z "$BUILDER_CACHE_THIS" ]; then
     mkdir -p /cache/new
 fi
 
+export SRC_VERSION=$BUILDER_VERSION
+OIFS=$IFS
+IFS='-' version_elems=($BUILDER_VERSION)
+IFS=$OIFS
+if [ ${#version_elems[@]} -gt 1 ]; then
+  # There's a dash in the version number, indicating a pre-release
+  # e.g. 1.2.3-alpha1.100.gaff36b2
+  # which would be split in 1.2.3 and alpha1.100.gaff36b2
+  BUILDER_VERSION=${version_elems[0]}
+  BUILDER_RELEASE="0.${version_elems[1]}.${BUILDER_RELEASE}"
+fi
+
 # Parse the specfiles to evaluate conditionals for builddeps, and store them in tempfiles
 # Also check for specs we need to skip (BUILDER_SKIP)
 tmpdir=$(mktemp -d /tmp/build-specs.parsed.XXXXXX)

--- a/helpers/functions.sh
+++ b/helpers/functions.sh
@@ -1,0 +1,100 @@
+# https://stackoverflow.com/questions/1527049/join-elements-of-an-array#17841619
+function join_by { local IFS="$1"; shift; echo "$*"; }
+
+set_debian_versions() {
+  # Examples (BUILDER_RELEASE before is assumed to be 1pdns
+  # BUILDER_VERSION                BUILDER_VERSION after        BUILDER_RELEASE after
+  # 1.2.3                       => 1.2.3                        1pdns
+  # 1.2.3.0.g123456             => 1.2.3+0.g123456              1pdns
+  # 1.2.3-alpha1                => 1.2.3~alpha1                 1pdns
+  # 1.2.3-alpha1.0.g123456      => 1.2.3~alpha1+0.g123456       1pdns
+  # 1.2.3-alpha1.15.g123456     => 1.2.3~alpha1+15.g123456      1pdns
+  # 1.2.3-rc2.12.branch.g123456 => 1.2.3~rc2+branch.12.g123456  1pdns
+  # 1.2.3.15.mybranch.g123456   => 1.2.3+mybranch.15.g123456    1pdns
+  # 1.2.3.15.g123456            => 1.2.3+15.g123456             1pdns
+  OIFS=$IFS
+  IFS='-' version_elems=($BUILDER_VERSION)
+  IFS=$OIFS
+  version=''
+  if [ ${#version_elems[@]} -gt 1 ]; then
+    version=${version_elems[0]}
+    OIFS=$IFS
+    IFS='.' version_elems=(${version_elems[1]})
+    IFS=$OIFS
+
+    # version_elems now contains e.g.
+    # alpha1
+    # alpha1 15 g123456
+    # alpha1 15 mybranch g123456
+    version="${version}~${version_elems[0]}"
+    if [ ${#version_elems[@]} -eq 3 ]; then
+      version="${version}+$(join_by . ${version_elems[@]:1})"
+    elif [ ${#version_elems[@]} -eq 4 ]; then
+      version="${version}+${version_elems[2]}.${version_elems[1]}.${version_elems[3]}"
+    fi
+  else
+    OIFS=$IFS
+    IFS='.' version_elems=(${BUILDER_VERSION})
+    IFS=$OIFS
+    # version_elems now contains e.g.
+    # 1 2 3
+    # 1 2 3 15 g123456
+    # 1 2 3 15 mybranch g123456
+    version=$(join_by . ${version_elems[@]:0:3})
+    if [ ${#version_elems[@]} -eq 5 ]; then
+      version="${version}+$(join_by . ${version_elems[@]:3})"
+    elif [ ${#version_elems[@]} -eq 6 ]; then
+      version="${version}+${version_elems[4]}.${version_elems[3]}.${version_elems[5]}"
+    fi
+  fi
+  BUILDER_VERSION=$version
+}
+
+set_rpm_versions() {
+  # Examples (BUILDER_RELEASE before is assumed to be 1pdns
+  # BUILDER_VERSION                BUILDER_VERSION after    BUILDER_RELEASE after
+  # 1.2.3                       => 1.2.3                    1pdns
+  # 1.2.3.0.g123456             => 1.2.3                    0.g123456.1pdns
+  # 1.2.3-alpha1                => 1.2.3                    0.alpha1.1pdns
+  # 1.2.3-alpha1.0.g123456      => 1.2.3                    0.alpha1.0.g12456.1pdns
+  # 1.2.3-alpha1.15.g123456     => 1.2.3                    0.alpha1.15.g12456.1pdns
+  # 1.2.3-rc2.12.branch.g123456 => 1.2.3                    0.rc2.branch.12.g123456.1pdns
+  # 1.2.3.15.mybranch.g123456   => 1.2.3                    mybranch.15.g123456.1pdns
+  # 1.2.3.15.g123456            => 1.2.3                    15.g123456.1pdns
+  OIFS=$IFS
+  IFS='-' version_elems=($BUILDER_VERSION)
+  IFS=$OIFS
+  prerel=''
+  if [ ${#version_elems[@]} -gt 1 ]; then
+    # There's a dash in the version number, indicating a pre-release
+    # Take the version number
+    BUILDER_VERSION=${version_elems[0]}
+    OIFS=$IFS
+    IFS='.' version_elems=(${version_elems[1]})
+    IFS=$OIFS
+    prerel="0.${version_elems[0]}."
+    version_elems=(${version_elems[@]:1})
+  else
+    OIFS=$IFS
+    IFS='.' version_elems=(${version_elems})
+    IFS=$OIFS
+    BUILDER_VERSION=$(join_by . ${version_elems[@]:0:3})
+    version_elems=(${version_elems[@]:3})
+  fi
+
+  # version_elems now contains everything _after_ the version, sans pre-release info
+  # e.g.
+  # (empty)
+  # 0 g123456
+  # 12 branch g123456
+  release=''
+  if [ ${#version_elems[@]} -eq 0 ]; then
+    # This is a release
+    BUILDER_RELEASE="${prerel}${BUILDER_RELEASE}"
+  elif [ ${#version_elems[@]} -gt 2 ]; then
+    # we have branch info
+    BUILDER_RELEASE="${prerel}${version_elems[1]}.${version_elems[0]}.${version_elems[2]}.${BUILDER_RELEASE}"
+  else
+    BUILDER_RELEASE="${prerel}${version_elems[0]}.${version_elems[1]}.${BUILDER_RELEASE}"
+  fi
+}

--- a/helpers/functions.sh
+++ b/helpers/functions.sh
@@ -3,7 +3,7 @@ function join_by { local IFS="$1"; shift; echo "$*"; }
 
 set_debian_versions() {
   # Examples (BUILDER_RELEASE before is assumed to be 1pdns
-  # BUILDER_VERSION                BUILDER_VERSION after        BUILDER_RELEASE after
+  # BUILDER_VERSION                BUILDER_DEB_VERSION after    BUILDER_DEB_RELEASE after
   # 1.2.3                       => 1.2.3                        1pdns
   # 1.2.3.0.g123456             => 1.2.3+0.g123456              1pdns
   # 1.2.3-alpha1                => 1.2.3~alpha1                 1pdns
@@ -47,20 +47,21 @@ set_debian_versions() {
       version="${version}+${version_elems[4]}.${version_elems[3]}.${version_elems[5]}"
     fi
   fi
-  BUILDER_VERSION=$version
+  export BUILDER_DEB_VERSION=$version
+  export BUILDER_DEB_RELEASE=${BUILDER_RELEASE}
 }
 
 set_rpm_versions() {
   # Examples (BUILDER_RELEASE before is assumed to be 1pdns
-  # BUILDER_VERSION                BUILDER_VERSION after    BUILDER_RELEASE after
-  # 1.2.3                       => 1.2.3                    1pdns
-  # 1.2.3.0.g123456             => 1.2.3                    0.g123456.1pdns
-  # 1.2.3-alpha1                => 1.2.3                    0.alpha1.1pdns
-  # 1.2.3-alpha1.0.g123456      => 1.2.3                    0.alpha1.0.g12456.1pdns
-  # 1.2.3-alpha1.15.g123456     => 1.2.3                    0.alpha1.15.g12456.1pdns
-  # 1.2.3-rc2.12.branch.g123456 => 1.2.3                    0.rc2.branch.12.g123456.1pdns
-  # 1.2.3.15.mybranch.g123456   => 1.2.3                    mybranch.15.g123456.1pdns
-  # 1.2.3.15.g123456            => 1.2.3                    15.g123456.1pdns
+  # BUILDER_VERSION                BUILDER_RPM_VERSION after  BUILDER_RPM_RELEASE after
+  # 1.2.3                       => 1.2.3                      1pdns
+  # 1.2.3.0.g123456             => 1.2.3                      0.g123456.1pdns
+  # 1.2.3-alpha1                => 1.2.3                      0.alpha1.1pdns
+  # 1.2.3-alpha1.0.g123456      => 1.2.3                      0.alpha1.0.g12456.1pdns
+  # 1.2.3-alpha1.15.g123456     => 1.2.3                      0.alpha1.15.g12456.1pdns
+  # 1.2.3-rc2.12.branch.g123456 => 1.2.3                      0.rc2.branch.12.g123456.1pdns
+  # 1.2.3.15.mybranch.g123456   => 1.2.3                      mybranch.15.g123456.1pdns
+  # 1.2.3.15.g123456            => 1.2.3                      15.g123456.1pdns
   OIFS=$IFS
   IFS='-' version_elems=($BUILDER_VERSION)
   IFS=$OIFS
@@ -68,7 +69,7 @@ set_rpm_versions() {
   if [ ${#version_elems[@]} -gt 1 ]; then
     # There's a dash in the version number, indicating a pre-release
     # Take the version number
-    BUILDER_VERSION=${version_elems[0]}
+    BUILDER_RPM_VERSION=${version_elems[0]}
     OIFS=$IFS
     IFS='.' version_elems=(${version_elems[1]})
     IFS=$OIFS
@@ -78,7 +79,7 @@ set_rpm_versions() {
     OIFS=$IFS
     IFS='.' version_elems=(${version_elems})
     IFS=$OIFS
-    BUILDER_VERSION=$(join_by . ${version_elems[@]:0:3})
+    BUILDER_RPM_VERSION=$(join_by . ${version_elems[@]:0:3})
     version_elems=(${version_elems[@]:3})
   fi
 
@@ -90,11 +91,12 @@ set_rpm_versions() {
   release=''
   if [ ${#version_elems[@]} -eq 0 ]; then
     # This is a release
-    BUILDER_RELEASE="${prerel}${BUILDER_RELEASE}"
+    export BUILDER_RPM_RELEASE="${prerel}${BUILDER_RELEASE}"
   elif [ ${#version_elems[@]} -gt 2 ]; then
     # we have branch info
-    BUILDER_RELEASE="${prerel}${version_elems[1]}.${version_elems[0]}.${version_elems[2]}.${BUILDER_RELEASE}"
+    export BUILDER_RPM_RELEASE="${prerel}${version_elems[1]}.${version_elems[0]}.${version_elems[2]}.${BUILDER_RELEASE}"
   else
-    BUILDER_RELEASE="${prerel}${version_elems[0]}.${version_elems[1]}.${BUILDER_RELEASE}"
+    export BUILDER_RPM_RELEASE="${prerel}${version_elems[0]}.${version_elems[1]}.${BUILDER_RELEASE}"
   fi
+  export BUILDER_RPM_VERSION
 }

--- a/tests/test_versioning.sh
+++ b/tests/test_versioning.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+assert_equal() {
+  if [ "$1" != "$2" ]; then
+    echo "${1} != ${2}"
+    exit 1
+  fi
+}
+
+set -e
+
+source "helpers/functions.sh"
+
+builder_release='1pdns'
+
+src_versions=(1.0.0
+              1.0.0-beta1
+              1.1.0-rc2.0.g123456
+              1.1.0.15.g123456
+              1.1.0.15.branchname.g123456
+              1.2.0-alpha1.10.branch.g123456)
+deb_versions=(1.0.0
+              1.0.0~beta1
+              1.1.0~rc2+0.g123456
+              1.1.0+15.g123456
+              1.1.0+branchname.15.g123456
+              1.2.0~alpha1+branch.10.g123456)
+rpm_versions=(1.0.0
+              1.0.0
+              1.1.0
+              1.1.0
+              1.1.0
+              1.2.0)
+rpm_releases=($builder_release
+              0.beta1.$builder_release
+              0.rc2.0.g123456.$builder_release
+              15.g123456.$builder_release
+              branchname.15.g123456.$builder_release
+              0.alpha1.branch.10.g123456.$builder_release)
+
+for ctr in ${!src_versions[@]}; do
+  BUILDER_VERSION=${src_versions[$ctr]}
+  BUILDER_RELEASE=$builder_release
+  set_debian_versions
+  assert_equal $BUILDER_VERSION ${deb_versions[$ctr]}
+  assert_equal $BUILDER_RELEASE $builder_release
+
+  BUILDER_VERSION=${src_versions[$ctr]}
+  BUILDER_RELEASE=$builder_release
+  set_rpm_versions
+  assert_equal $BUILDER_VERSION ${rpm_versions[$ctr]}
+  assert_equal $BUILDER_RELEASE ${rpm_releases[$ctr]}
+done

--- a/tests/test_versioning.sh
+++ b/tests/test_versioning.sh
@@ -42,12 +42,13 @@ for ctr in ${!src_versions[@]}; do
   BUILDER_VERSION=${src_versions[$ctr]}
   BUILDER_RELEASE=$builder_release
   set_debian_versions
-  assert_equal $BUILDER_VERSION ${deb_versions[$ctr]}
-  assert_equal $BUILDER_RELEASE $builder_release
+  assert_equal $BUILDER_DEB_VERSION ${deb_versions[$ctr]}
+  assert_equal $BUILDER_DEB_RELEASE $builder_release
 
-  BUILDER_VERSION=${src_versions[$ctr]}
-  BUILDER_RELEASE=$builder_release
   set_rpm_versions
-  assert_equal $BUILDER_VERSION ${rpm_versions[$ctr]}
-  assert_equal $BUILDER_RELEASE ${rpm_releases[$ctr]}
+  assert_equal $BUILDER_RPM_VERSION ${rpm_versions[$ctr]}
+  assert_equal $BUILDER_RPM_RELEASE ${rpm_releases[$ctr]}
+
+  assert_equal $BUILDER_VERSION ${src_versions[$ctr]}
+  assert_equal $BUILDER_RELEASE $builder_release
 done


### PR DESCRIPTION
When tagging e.g. with `1.2.3-alpha1`, the rpms and debian packages will follow the following conventions (when `IS_RELEASE=YES`:

* RPM: `1.2.3-0.alpha1.$BUILDER_RELEASE`
* DEB: `1.2.3~alpha1-$BUILDER_RELEASE`

When IS_RELEASE is not set, the following is used:

* RPM: `1.2.3-0.alpha1.$COMMITS_SINCE_TAG.$GIT_HASH.$BUILDER_RELEASE`
* DEB: `1.2.3~alpha1-0.$COMMITS_SINCE_TAG.$GIT_HASH.$BUILDER_RELEASE`

