### PR TITLE
centos demo build: ask for any python3

### DIFF
--- a/demo/builder-support/dockerfiles/Dockerfile.target.centos-7
+++ b/demo/builder-support/dockerfiles/Dockerfile.target.centos-7
@@ -7,7 +7,7 @@ FROM centos:7 as dist-base
 ARG BUILDER_CACHE_BUSTER=
 RUN yum install -y epel-release
 # Python 3.4+ is needed for the builder helpers
-RUN yum install -y python36
+RUN yum install -y /usr/bin/python3
 
 # Do the actual rpm build
 @INCLUDE Dockerfile.rpmbuild


### PR DESCRIPTION
`python34` no longer installs `/usr/bin/python3`. (`python36` does now, but this change is future proof)