### PR TITLE
Support debian pre-releases

### DIFF
--- a/demo/builder-support/dockerfiles/Dockerfile.target.centos-7
+++ b/demo/builder-support/dockerfiles/Dockerfile.target.centos-7
@@ -7,7 +7,7 @@ FROM centos:7 as dist-base
 ARG BUILDER_CACHE_BUSTER=
 RUN yum install -y epel-release
 # Python 3.4+ is needed for the builder helpers
-RUN yum install -y python34
+RUN yum install -y python36
 
 # Do the actual rpm build
 @INCLUDE Dockerfile.rpmbuild

--- a/helpers/build-debs.sh
+++ b/helpers/build-debs.sh
@@ -52,6 +52,9 @@ for dir in "${dirs[@]}"; do
       distro_release="$(perl -n -e '/VERSION=".* \((.*)\)"/ && print $1' /etc/os-release)"
     fi
     if [ -z "${distro_release}" ]; then
+      distro_release="$(perl -n -e '/PRETTY_NAME="Debian GNU\/Linux (.*)\/sid"/ && print $1' /etc/os-release)"
+    fi
+    if [ -z "${distro_release}" ]; then
       echo 'Unable to determine distribution codename!'
       exit 1
     fi


### PR DESCRIPTION
This ensures we properly get the distribution name when /etc/os-release
does not have VERSION set, attempt to get the release from PRETTY_NAME,
which is set to `Debian GNU/Linux $upcoming_release/sid`.