### PR TITLE
build.sh: do not change working directory when rendering the target dockerfile template

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -225,9 +225,9 @@ set -e
 #dockerfile="Dockerfile_${target}_${BUILDER_VERSION}" 
 dockerfile="Dockerfile_${target}.tmp"
 dockerfilepath="$BUILDER_TMP/$dockerfile"
-cd "$BUILDER_SUPPORT_ROOT/dockerfiles"
-BUILDER_TARGET="$target" tmpl_debug=1 tmpl_comment='###' "$BUILDER_ROOT/templating/templating.sh" "$template" > "$dockerfilepath"
-cd - > /dev/null
+
+BUILDER_TARGET="$target" tmpl_debug=1 tmpl_comment='###' "$BUILDER_ROOT/templating/templating.sh" "$templatepath" > "$dockerfilepath"
+
 [ -z "$quiet" ] && echo "Generated $dockerfilepath"
 
 #######################################################################

--- a/demo/builder-support/dockerfiles/Dockerfile.target.centos-7
+++ b/demo/builder-support/dockerfiles/Dockerfile.target.centos-7
@@ -14,5 +14,6 @@ RUN yum install -y /usr/bin/python3
 
 # Do a test install and verify
 # Can be skipped with skiptests=1 in the environment
-@EXEC [ "$skiptests" = "" ] && include Dockerfile.rpmtest
-
+@IF [ "$skiptests" = "" ]
+@INCLUDE Dockerfile.rpmtest
+@ENDIF

--- a/templating/templating.sh
+++ b/templating/templating.sh
@@ -38,21 +38,20 @@ include() {
 
         elif [ ! -z "$skip" ]; then
             # nothing, in IF that evaluated to false
-            [ "$tmpl_debug" != "" ] && echo "$tmpl_comment     $line"
-            
+            [ "$tmpl_debug" != "" ] && echo "$tmpl_comment $line"
 
         elif [[ $line = ${tmpl_prefix}INCLUDE\ * ]]; then
-            include=${line#* }
+            include=$(find . -type f -name ${line#* } | head -n 1)
             include $include
 
         elif [[ $line = ${tmpl_prefix}EVAL\ * ]]; then
             line=${line#* }
             eval echo "\"$line\""
-        
+
         elif [[ $line = ${tmpl_prefix}EXEC\ * ]]; then
             line=${line#* }
             eval "$line"
-        
+
         elif [[ $line = ${tmpl_prefix}IF\ * ]]; then
             condition=${line#* }
             [ "$tmpl_debug" != "" ] && echo "$tmpl_comment $line"


### PR DESCRIPTION
The rendering of the target dockerfile template the build of the resulting docker image are now performed by the `build.sh` script without changing working directory.

This change allows, e.g., to use the following snippet in the `Dockerfile.target.sdist` template to `ADD` C++ source files to the build dockerimage.

```
@EXEC sdist_files=$(find . -maxdepth 1 -type f \( -iname \*.hh -o -iname \*.cc \) -exec basename {} \;)
@EXEC for f in ${sdist_files[@]} ; do echo "ADD $f /build/src/$f" ; done
```