### PR TITLE
Add a new flag to override the default docker build ulimits

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -68,6 +68,7 @@ usage() {
     echo "Options:"
     echo "  -B ARG=VAL      - Add extra build arguments, can be passed more than once"
     echo "  -C              - Run docker build with --no-cache"
+    echo "  -L <limit>=<softlimit>:<hardlimit> - Overrides the default docker daemon ulimits, can be passed more than once"
     echo "  -c              - Enable builder package cache"
     echo "  -V VERSION      - Override version (default: run gen-version)"
     echo "  -R RELEASE      - Override release tag (default: '1pdns', do not include %{dist} here)"
@@ -113,7 +114,7 @@ BUILDER_MODULES=''
 package_match=""
 cache_buster=""
 
-while getopts ":CcV:R:svqm:Pp:b:e:B:" opt; do
+while getopts ":CcV:R:svqm:Pp:b:e:B:L:" opt; do
     case $opt in
     C)  dockeropts+=('--no-cache')
         ;;
@@ -154,6 +155,8 @@ while getopts ":CcV:R:svqm:Pp:b:e:B:" opt; do
     b)  cache_buster="$OPTARG"
         ;;
     B)  buildargs+=("--build-arg ${OPTARG}")
+        ;;
+    L)  buildargs+=("--ulimit" "${OPTARG}")
         ;;
     \?) echo "Invalid option: -$OPTARG" >&2
         usage


### PR DESCRIPTION
Investigating some issues with the `yum` command being very slow in the official `centos:7` images, we've discovered that by default, docker sets a very high number for the `nofile` file ulimit

```bash
% docker run --rm centos:7 bash -c "ulimit -a"
core file size          (blocks, -c) unlimited
data seg size           (kbytes, -d) unlimited
scheduling priority             (-e) 0
file size               (blocks, -f) unlimited
pending signals                 (-i) 30578
max locked memory       (kbytes, -l) 65536
max memory size         (kbytes, -m) unlimited
open files                      (-n) 1073741816
pipe size            (512 bytes, -p) 8
POSIX message queues     (bytes, -q) 819200
real-time priority              (-r) 0
stack size              (kbytes, -s) 8192
cpu time               (seconds, -t) unlimited
max user processes              (-u) unlimited
virtual memory          (kbytes, -v) unlimited
file locks                      (-x) unlimited
```

Unfortunately, as reported in https://github.com/moby/moby/issues/23137, this has some issues with some versions of yum resulting in painfully slow execution of basics `yum install` commands.
In my case, a simple `yum install -y rpm-build rpmdevtools && yum groupinstall -y "Development Tools"` took more than 6h.

The issue has been fixed upstream in https://bugzilla.redhat.com/show_bug.cgi?id=1537564, however the default `centos:7` image is still shipping with a version of yum without the patch.

In order to mitigate this issue there are two options:
- override the default docker daemon ulimits in its configuration
- override the ulimits at build time using the `--ulimit` CLI option

This PR implements the second option adding a `-L` option to the `./build.sh` command to be used as shown below

```
./build.sh -c -s -L nofile=1024:1024 centos-7
```

This simple fix reduced the build time of our application in a minikube based Docker system from ~10h to ~15 minutes.