### PR TITLE
Strip a leading 'v' in the version number

### DIFF
--- a/gen-version
+++ b/gen-version
@@ -88,4 +88,4 @@ if [ ! -z "$(git rev-parse --abbrev-ref HEAD 2> /dev/null)" ]; then
   VERSION="${LAST_TAG}.${COMMITS_SINCE_TAG}${BRANCH}.${GIT_HASH}${DIRTY}"
 fi
 
-printf $VERSION
+printf $VERSION | perl -p -e 's/^v//;'


### PR DESCRIPTION
Projects that tag with vX.Y.Z will get correct version numbers this way