### PR TITLE
Add Kaniko support to the builder

### DIFF
--- a/Dockerfile-kaniko
+++ b/Dockerfile-kaniko
@@ -1,0 +1,18 @@
+FROM alpine:3.11
+
+ENV DOCKER_CONFIG='/kaniko/.docker'
+ENV GOOGLE_APPLICATION_CREDENTIALS='/kaniko/.docker/config.json'
+ENV PATH=/kaniko:$PATH
+ENV SSL_CERT_DIR=/kaniko/ssl/certs
+
+RUN apk --no-cache add \
+      bash \
+      git \
+      grep \
+      perl \
+      sed \
+      tree
+
+COPY --from=gcr.io/kaniko-project/executor /kaniko /kaniko
+
+ENTRYPOINT ["/kaniko/executor"]


### PR DESCRIPTION
This adds support for running pdns-builder with [kaniko](https://github.com/GoogleContainerTools/kaniko) instead of docker. This is required when the CI running is on k8s and docker-in-docker is not available (e.g. because the cluster uses runc, the cluster admin does not want privileged containers or the docker socket can't be exposed).

The kaniko executor must be available at /kaniko/executor. A dockerfile is added to build an Alpine image that has the executor and the minimal set of dependencies required for pdns-builder to run.

To use kaniko, the `-K` must be passed to build.sh.

Kaniko can cache layers to a registry. To accomplish this, the `-k URL` flag can be set.

An example of how to use this within GitLab-CI looks like this:

```yaml
CentOS 7 pkg:
  image:
    name: lieter/pdns-builder-kaniko:latest
  stage: Build packages
  variables:
    GIT_SUBMODULE_STRATEGY: normal
  script:
    -  echo "{\"auths\": {\"$CI_REGISTRY\": {\"username\": \"$CI_REGISTRY_USER\", \"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > /kaniko/.docker/config.json
    - ./builder/build.sh -s -k $CI_REGISTRY_IMAGE/pdns-builder-cache -K centos-7
    - mv /dist dist
  artifacts:
    paths:
      - dist/*
```

I've tested this extensively in a private gitlab repo