### PR TITLE
Enable parallelism for builds of Debian packages

### DIFF
--- a/helpers/build-debs.sh
+++ b/helpers/build-debs.sh
@@ -74,6 +74,9 @@ $sourcename (${epoch_string}${BUILDER_DEB_VERSION}-${BUILDER_DEB_RELEASE}.${dist
 EOF
   fi
 
+  # allow build to use all available processors
+  export DEB_BUILD_OPTIONS='parallel='`nproc`
+
   fakeroot debian/rules binary || exit 1
   popd
 done


### PR DESCRIPTION
DEB_BUILD_OPTIONS must be set to a value greater than '1' for the debhelper to invoke 'make' with multiple job support.

This change results in the same behavior exhibited by RPM builds (where parallelism is used by default).