### PR TITLE
Reproducible RPM builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,6 @@ script:
   - ./builder/build.sh -c -B MYCOOLARG=iLikeTests centos-7
   # - Third one is very fast due to the Docker layer cache
   - ./builder/build.sh -c -B MYCOOLARG=iLikeTests centos-7
+  # Do a reproducible centos-8 build (does not work for centos-7)
+  - ../tests/test-centos-8-reproducible.sh
 

--- a/build.sh
+++ b/build.sh
@@ -91,7 +91,7 @@ usage() {
     echo "  -V VERSION      - Override version (default: run gen-version)"
     echo "  -R RELEASE      - Override release tag (default: '1pdns', do not include %{dist} here)"
     echo "  -m MODULES      - Build only specific components (comma separated; warning: this disables install tests)"
-    echo "  -e EPOCH        - Set a specific Epoch for RPM packages"
+    echo "  -e EPOCH        - Set a specific version Epoch for RPM/DEB packages"
     echo "  -b VALUE        - Docker cache buster, set to 'always', 'daily', 'weekly' or a literal value."
     echo "  -p PACKAGENAME  - Build only spec files that have this string in their name (warning: this disables install tests)"
     echo "  -q              - Be more quiet. Build error details are still printed on build error."

--- a/demo/README.md
+++ b/demo/README.md
@@ -6,7 +6,7 @@ and as a test case for builder development.
 To run the build, run this from the current folder:
 
     ./prepare.sh
-    ./builder/build.sh
+    ./builder/build.sh -B MYCOOLARG=iLikeTests
 
 The prepare script copies the builder files into builder/. Generally
 you would use git submodules instead, but this does not work for here

--- a/demo/builder-support/dockerfiles/Dockerfile.rpmbuild
+++ b/demo/builder-support/dockerfiles/Dockerfile.rpmbuild
@@ -36,7 +36,7 @@ RUN mkdir /cache/new
 # Only vendor specs can safely use the builder cache for these reasons.
 @IF [ ! -z "$M_all$M_vendor" ]
 COPY builder-support/vendor-specs/ builder-support/vendor-specs/
-RUN BUILDER_CACHE_THIS=1 builder/helpers/build-specs.sh builder-support/vendor-specs/*.spec
+RUN BUILDER_CACHE_THIS=1 BUILDER_SOURCE_DATE_FROM_SPEC_MTIME=1 builder/helpers/build-specs.sh builder-support/vendor-specs/*.spec
 @ENDIF
 
 # You can override these build args for faster Python builds
@@ -48,6 +48,7 @@ RUN BUILDER_CACHE_THIS=1 builder/helpers/build-specs.sh builder-support/vendor-s
 # Set after vendor builds to not invalidate their cached layers every time
 ARG BUILDER_VERSION
 ARG BUILDER_RELEASE
+ARG SOURCE_DATE_EPOCH
 COPY --from=sdist /sdist /sdist
 RUN for file in /sdist/* ; do ln -s $file /root/rpmbuild/SOURCES/ ; done && ls /root/rpmbuild/SOURCES/
 

--- a/demo/builder-support/dockerfiles/Dockerfile.target.centos-8
+++ b/demo/builder-support/dockerfiles/Dockerfile.target.centos-8
@@ -1,0 +1,20 @@
+# First do the source builds
+@INCLUDE Dockerfile.target.sdist
+
+# This defines the dstribution base layer
+# Put only the bare minimum of common commands here, without dev tools
+FROM centos:8 as dist-base
+ARG BUILDER_CACHE_BUSTER=
+RUN yum install -y epel-release
+# Python 3.4+ is needed for the builder helpers
+RUN yum install -y /usr/bin/python3
+RUN yum install -y dnf-plugins-core
+RUN yum config-manager --set-enabled powertools
+
+# Do the actual rpm build
+@INCLUDE Dockerfile.rpmbuild
+
+# Do a test install and verify
+# Can be skipped with skiptests=1 in the environment
+@EXEC [ "$skiptests" = "" ] && include Dockerfile.rpmtest
+

--- a/demo/builder-support/dockerfiles/Dockerfile.target.sdist
+++ b/demo/builder-support/dockerfiles/Dockerfile.target.sdist
@@ -3,10 +3,11 @@
 # =========================================================================
 # Deliberately using alpine with incompatible libc to ensure we are
 # not sneaking in any binaries, and because it's light and up to date.
-FROM alpine:3.7 as sdist
+FROM alpine:3.13 as sdist
 ARG BUILDER_CACHE_BUSTER=
 RUN apk add --no-cache tar
 ARG BUILDER_VERSION
+ARG SOURCE_DATE_EPOCH
 
 # Copying minimal set of files to avoid cache invalidation
 RUN mkdir /build
@@ -20,12 +21,12 @@ RUN test "${MYCOOLARG}" = 'iLikeTests'
 
 # Build module A
 @IF [ ! -z "$M_all$M_a" ]
-RUN cd src/ && tar -cvzf /sdist/demo-a-$BUILDER_VERSION.tar.gz --transform "s,^,demo-a-$BUILDER_VERSION/," demo-a.sh
+RUN cd src/ && tar --clamp-mtime --mtime="$SOURCE_DATE_EPOCH" -cvzf /sdist/demo-a-$BUILDER_VERSION.tar.gz --transform "s,^,demo-a-$BUILDER_VERSION/," demo-a.sh
 @ENDIF
 
 # Build module B
 @IF [ ! -z "$M_all$M_a" ]
-RUN cd src/ && tar -cvzf /sdist/demo-b-$BUILDER_VERSION.tar.gz --transform "s,^,demo-b-$BUILDER_VERSION/," demo-b.sh
+RUN cd src/ && tar --clamp-mtime --mtime="$SOURCE_DATE_EPOCH" -cvzf /sdist/demo-b-$BUILDER_VERSION.tar.gz --transform "s,^,demo-b-$BUILDER_VERSION/," demo-b.sh
 @ENDIF
 
 # Show contents for build debugging

--- a/tests/test-centos-8-reproducible.sh
+++ b/tests/test-centos-8-reproducible.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Test if centos-8 RPM builds are reproducible
+# Must be run from demo dir
+
+set -ex
+
+# First build
+./builder/build.sh -B MYCOOLARG=iLikeTests centos-8
+
+# Record hashes
+sha256sum \
+    builder/tmp/latest/centos-8/dist/noarch/*.rpm \
+    builder/tmp/latest/sdist/*.tar.gz \
+    > /tmp/sha256sum.txt
+
+# Second build after cleaning and adding a file to invaldiate the build context
+rm -rf ./builder/tmp/latest/centos-8
+rm -rf ./builder/tmp/latest/sdist
+./builder/build.sh -B MYCOOLARG=iLikeTests -b build-again centos-8
+
+# Check hashes, should be identical
+sha256sum -c /tmp/sha256sum.txt
+


### PR DESCRIPTION
Reproducible RPM builds and `SOURCE_DATE_EPOCH` env var.

Note that this only works for RHEL 8+ and derived distributions, as the RPM version in RHEL 7 does not support reproducible builds.

Progress

- [x] Pass `SOURCE_DATE_EPOCH` env var as a build arg (up to the Dockerfiles to explicitly use it)
- [x] Set `SOURCE_DATE_EPOCH` to last commit time if not set
- [x] Define magic variables to kindly ask rpmbuild for reproducible RPM builds 
    - [ ] Discuss: is it OK to always set these? Perhaps only if `SOURCE_DATE_EPOCH` is set?
- [x] Example of args to pass to tar in demo
- [x] Add centos-8 as demo target
- [x] Upgrade alpine 
- [x] Also make it work for the vendor RPM without breaking the Docker cache layers by using the last commit time
- [x] CI test reproducible RPM build using centos-8 target (does not work with centos-7)
- [x] Add a few words on this to the README
- [x] Cleanup PR when everything works
