### PR TITLE
PEP 440 compliant Python BUILDER_PYTHON_SRC_VERSION

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -251,6 +251,10 @@ else
 fi
 export BUILDER_VERSION
 
+# Set other version formats that need to be available as build args
+source "$BUILDER_ROOT/helpers/functions.sh"
+set_python_src_versions  # sets BUILDER_PYTHON_SRC_VERSION
+
 # Set SOURCE_DATE_EPOCH to last commit timestamp, if unset
 # See https://reproducible-builds.org/docs/source-date-epoch/
 # It is still up to the Dockerfile to actually set this
@@ -292,6 +296,7 @@ buildargs+=("--build-arg" "BUILDER_VERSION=$BUILDER_VERSION")
 buildargs+=("--build-arg" "BUILDER_RELEASE=$BUILDER_RELEASE")
 buildargs+=("--build-arg" "BUILDER_PACKAGE_MATCH=$package_match")
 buildargs+=("--build-arg" "BUILDER_EPOCH=$BUILDER_EPOCH")
+buildargs+=("--build-arg" "BUILDER_PYTHON_SRC_VERSION=$BUILDER_PYTHON_SRC_VERSION")
 buildargs+=("--build-arg" "APT_URL=$APT_URL")
 buildargs+=("--build-arg" "PIP_INDEX_URL=$PIP_INDEX_URL")
 buildargs+=("--build-arg" "PIP_TRUSTED_HOST=$PIP_TRUSTED_HOST")

--- a/helpers/functions.sh
+++ b/helpers/functions.sh
@@ -16,7 +16,8 @@ set_python_src_versions() {
   # 1.2.3.15.mybranch.g123456   => 1.2.3+15.mybranch.g123456
   # 1.2.3.15.g123456            => 1.2.3+15.g123456
   # 1.2.3.15.g123456.dirty      => 1.2.3+15.g123456.dirty
-  export BUILDER_PYTHON_SRC_VERSION="$(echo ${BUILDER_VERSION} | perl -pe 's,-alpha([0-9]+),a\1+,' | perl -pe 's,-beta([0-9]+),b\1+,' | perl -pe 's,-rc([0-9]+),rc\1+,' | perl -pe 's,\+$,,' | perl -pe 's,\+\.,+,' | perl -pe 's,^([0-9]+\.[0-9]+\.[0-9]+)\.(.*)$,\1+\2,' )"
+  # 1.2.3.130.HEAD.gbac839b2    => 1.2.3+130.head.gbac839b2
+  export BUILDER_PYTHON_SRC_VERSION="$(echo ${BUILDER_VERSION} | perl -pe 's,-alpha([0-9]+),a\1+,' | perl -pe 's,-beta([0-9]+),b\1+,' | perl -pe 's,-rc([0-9]+),rc\1+,' | perl -pe 's,\+$,,' | perl -pe 's,\+\.,+,' | perl -pe 's,^([0-9]+\.[0-9]+\.[0-9]+)\.(.*)$,\1+\2,' | tr A-Z a-z )"
 }
 
 set_debian_versions() {

--- a/helpers/functions.sh
+++ b/helpers/functions.sh
@@ -2,19 +2,21 @@
 function join_by { local IFS="$1"; shift; echo "$*"; }
 
 set_python_src_versions() {
-  # setuptools is very strict about PEP 440. SO we need some magic to make this go away
-  # TODO real PEP 440 support
+  # setuptools is very strict about PEP 440
+  # See https://peps.python.org/pep-0440/
 
-  # BUILDER_VERSION                BUILDER_PYTHON_SRC_VERSION       REAL PEP 440
-  # 1.2.3                       => 1.2.3                            1.2.3
-  # 1.2.3.0.g123456             => 1.2.3.0.g123456                  1.2.3+0.g123456
-  # 1.2.3-alpha1                => 1.2.3a1                          1.2.3a1
-  # 1.2.3-alpha1.0.g123456      => 1.2.3-alpha1.0.g123456           1.2.3a1+0.g123456
-  # 1.2.3-alpha1.15.g123456     => 1.2.3-alpha1.15.g123456          1.2.3a1+15.g123456
-  # 1.2.3-rc2.12.branch.g123456 => 1.2.3-rc2.branch.12.g123456      1.2.3rc2+branch.12.g123456
-  # 1.2.3.15.mybranch.g123456   => 1.2.3.15.mybranch.g123456        1.2.3+mybranch.15.g123456
-  # 1.2.3.15.g123456            => 1.2.3.15.g123456                 1.2.3+15.g123456
-  export BUILDER_PYTHON_SRC_VERSION="$(echo ${BUILDER_VERSION} | perl -pe 's,-alpha([0-9]+)$,a\1,' | perl -pe 's,-beta([0-9]+)$,b\1,' | perl -pe 's,-rc([0-9]+)$,rc\1,')"
+  # BUILDER_VERSION                BUILDER_PYTHON_SRC_VERSION
+  # 1.2.3                       => 1.2.3
+  # 1.2.3.dirty                 => 1.2.3+dirty
+  # 1.2.3.0.g123456             => 1.2.3+0.g123456
+  # 1.2.3-alpha1                => 1.2.3a1
+  # 1.2.3-alpha1.0.g123456      => 1.2.3a1+0.g123456
+  # 1.2.3-alpha1.15.g123456     => 1.2.3a1+15.g123456
+  # 1.2.3-rc2.12.branch.g123456 => 1.2.3rc2+branch.12.g123456
+  # 1.2.3.15.mybranch.g123456   => 1.2.3+15.mybranch.g123456
+  # 1.2.3.15.g123456            => 1.2.3+15.g123456
+  # 1.2.3.15.g123456.dirty      => 1.2.3+15.g123456.dirty
+  export BUILDER_PYTHON_SRC_VERSION="$(echo ${BUILDER_VERSION} | perl -pe 's,-alpha([0-9]+),a\1+,' | perl -pe 's,-beta([0-9]+),b\1+,' | perl -pe 's,-rc([0-9]+),rc\1+,' | perl -pe 's,\+$,,' | perl -pe 's,\+\.,+,' | perl -pe 's,^([0-9]+\.[0-9]+\.[0-9]+)\.(.*)$,\1+\2,' )"
 }
 
 set_debian_versions() {

--- a/tests/test_versioning.sh
+++ b/tests/test_versioning.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
+exitcode=0
 assert_equal() {
-  if [ "$1" != "$2" ]; then
-    echo "${1} != ${2}"
-    exit 1
+  if [ "$2" != "$3" ]; then
+    echo "${1}: ${2} != ${3}"
+    exitcode=1
   fi
 }
 
@@ -62,34 +63,36 @@ rpm_releases=($builder_release
               0.alpha1.branch.10.g123456.$builder_release
               0.alpha1.branch.10.g123456.dirty.$builder_release)
 
-# note, these do not comply to PEP 440
+# These comply to PEP 440
 py_versions=(1.0.0
-             1.0.0.dirty
+             1.0.0+dirty
              1.0.0b1
-             1.0.0-beta1.dirty
-             1.1.0-rc2.0.g123456
-             1.1.0-rc2.0.g123456.dirty
-             1.1.0.15.g123456
-             1.1.0.15.g123456.dirty
-             1.1.0.15.branchname.g123456
-             1.1.0.15.branchname.g123456.dirty
-             1.2.0-alpha1.10.branch.g123456
-             1.2.0-alpha1.10.branch.g123456.dirty)
+             1.0.0b1+dirty
+             1.1.0rc2+0.g123456
+             1.1.0rc2+0.g123456.dirty
+             1.1.0+15.g123456
+             1.1.0+15.g123456.dirty
+             1.1.0+15.branchname.g123456
+             1.1.0+15.branchname.g123456.dirty
+             1.2.0a1+10.branch.g123456
+             1.2.0a1+10.branch.g123456.dirty)
 
 for ctr in ${!src_versions[@]}; do
   BUILDER_VERSION=${src_versions[$ctr]}
   BUILDER_RELEASE=$builder_release
   set_debian_versions
-  assert_equal $BUILDER_DEB_VERSION ${deb_versions[$ctr]}
-  assert_equal $BUILDER_DEB_RELEASE $builder_release
+  assert_equal BUILDER_DEB_VERSION $BUILDER_DEB_VERSION ${deb_versions[$ctr]}
+  assert_equal BUILDER_DEB_RELEASE $BUILDER_DEB_RELEASE $builder_release
 
   set_rpm_versions
-  assert_equal $BUILDER_RPM_VERSION ${rpm_versions[$ctr]}
-  assert_equal $BUILDER_RPM_RELEASE ${rpm_releases[$ctr]}
+  assert_equal BUILDER_RPM_VERSION $BUILDER_RPM_VERSION ${rpm_versions[$ctr]}
+  assert_equal BUILDER_RPM_RELEASE $BUILDER_RPM_RELEASE ${rpm_releases[$ctr]}
 
   set_python_src_versions
-  assert_equal $BUILDER_PYTHON_SRC_VERSION ${py_versions[$ctr]}
+  assert_equal BUILDER_PYTHON_SRC_VERSION $BUILDER_PYTHON_SRC_VERSION ${py_versions[$ctr]}
 
-  assert_equal $BUILDER_VERSION ${src_versions[$ctr]}
-  assert_equal $BUILDER_RELEASE $builder_release
+  assert_equal BUILDER_VERSION $BUILDER_VERSION ${src_versions[$ctr]}
+  assert_equal BUILDER_RELEASE $BUILDER_RELEASE $builder_release
 done
+
+exit "$exitcode"

--- a/tests/test_versioning.sh
+++ b/tests/test_versioning.sh
@@ -25,7 +25,8 @@ src_versions=(1.0.0
               1.1.0.15.branchname.g123456
               1.1.0.15.branchname.g123456.dirty
               1.2.0-alpha1.10.branch.g123456
-              1.2.0-alpha1.10.branch.g123456.dirty)
+              1.2.0-alpha1.10.branch.g123456.dirty
+              1.2.3.130.HEAD.gbac839b2)
 deb_versions=(1.0.0
               1.0.0+dirty
               1.0.0~beta1
@@ -37,7 +38,8 @@ deb_versions=(1.0.0
               1.1.0+branchname.15.g123456
               1.1.0+branchname.15.g123456.dirty
               1.2.0~alpha1+branch.10.g123456
-              1.2.0~alpha1+branch.10.g123456.dirty)
+              1.2.0~alpha1+branch.10.g123456.dirty
+              1.2.3+HEAD.130.gbac839b2)
 rpm_versions=(1.0.0
               1.0.0
               1.0.0
@@ -49,7 +51,8 @@ rpm_versions=(1.0.0
               1.1.0
               1.1.0
               1.2.0
-              1.2.0)
+              1.2.0
+              1.2.3)
 rpm_releases=($builder_release
               dirty.$builder_release
               0.beta1.$builder_release
@@ -61,7 +64,8 @@ rpm_releases=($builder_release
               branchname.15.g123456.$builder_release
               branchname.15.g123456.dirty.$builder_release
               0.alpha1.branch.10.g123456.$builder_release
-              0.alpha1.branch.10.g123456.dirty.$builder_release)
+              0.alpha1.branch.10.g123456.dirty.$builder_release
+              HEAD.130.gbac839b2.$builder_release)
 
 # These comply to PEP 440
 py_versions=(1.0.0
@@ -75,7 +79,8 @@ py_versions=(1.0.0
              1.1.0+15.branchname.g123456
              1.1.0+15.branchname.g123456.dirty
              1.2.0a1+10.branch.g123456
-             1.2.0a1+10.branch.g123456.dirty)
+             1.2.0a1+10.branch.g123456.dirty
+             1.2.3+130.head.gbac839b2)
 
 for ctr in ${!src_versions[@]}; do
   BUILDER_VERSION=${src_versions[$ctr]}


### PR DESCRIPTION
Make `BUILDER_PYTHON_SRC_VERSION` [PEP 440](https://peps.python.org/pep-0440/) compliant, and pass it as a build arg.

Setuptools 66 (Jan 2023) turned version format warnings into errors, breaking builds.
See https://github.com/pypa/setuptools/issues/3772 for more information

To fix Python builds:

- Add `ARG BUILDER_PYTHON_SRC_VERSION` to your Dockerfile
- You can also add `RUN test -n "$BUILDER_PYTHON_SRC_VERSION"` to check that it is actually set
- Use `BUILDER_PYTHON_SRC_VERSION` instead of `BUILDER_VERSION` as your package version in `setup.py` (do not read the env var from there, but write it to a `version.txt` that is explicitly packaged in your `MANIFEST.in`, and read that file)

