### PR TITLE
Fix buildkit default logging in recent docker versions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -351,7 +351,7 @@ else
 
     docker_steps_output() {
       # Only display steps, with FROM commands in bold
-      grep --line-buffered -E '^(Step [0-9]|::: )' | sed "$sed_nobuf" -E "s/^(Step [0-9].* )(FROM .*)$/\\1${color_white_e}\\2${color_reset_e}/" | timestamp > "$dockeroutdev"
+      grep --line-buffered -E '^(Step [0-9]|::: |^#[0-9]+ (\[|[0-9.]+ :::))' | sed "$sed_nobuf" -E "s/^(Step [0-9].* )(FROM .*)$/\\1${color_white_e}\\2${color_reset_e}/; s/^#[0-9]+ //" | timestamp > "$dockeroutdev"
     }
 
     kaniko_steps_output() {


### PR DESCRIPTION
With recent docker versions that use buildkit, the build did not show any output by default. This resolves it by showing similar output as old non-buildkit docker builds.

Example output:

```
[ 0:01] [internal] load build definition from Dockerfile_centos-7.tmp
[ 0:01] [internal] load .dockerignore
[ 0:01] [internal] load metadata for docker.io/library/alpine:3.13
[ 0:01] [internal] load metadata for docker.io/library/centos:7
[ 0:02] [dist-base 1/2] FROM docker.io/library/centos:7@sha256:be65f488b7764ad3638f236b7b515b3678369a5124c47b8d32916d6487418ea4
[ 0:02] [ouidb 1/5] FROM docker.io/library/alpine:3.13
[ 0:02] [internal] load build context
[ 0:02] [dist-base 2/3] RUN yum install -y epel-release
[ 0:02] [dist-base 3/3] RUN yum install -y /usr/bin/python3
[ 0:02] [sdist  6/11] COPY src/ src/
[ 0:02] [sdist  9/11] RUN cd src/ && tar --clamp-mtime --mtime="@1683709939" -cvzf /sdist/demo-a-0.1.42.81.templatesnestedif.ga7bc551.dirty.tar.gz --transform "s,^,demo-a-0.1.42.81.templatesnestedif.ga7bc551.dirty/," demo-a.sh
[ 0:02] [sdist  7/11] RUN mkdir /sdist
[ 0:02] [sdist  8/11] RUN test "iLikeTests" = 'iLikeTests'
[ 0:02] [sdist  2/11] RUN apk add --no-cache tar
[ 0:02] [sdist 10/11] RUN cd src/ && tar --clamp-mtime --mtime="@1683709939" -cvzf /sdist/demo-b-0.1.42.81.templatesnestedif.ga7bc551.dirty.tar.gz --transform "s,^,demo-b-0.1.42.81.templatesnestedif.ga7bc551.dirty/," demo-b.sh
[ 0:02] [sdist  3/11] RUN echo "::: SOURCE_DATE_EPOCH=1683709939"; if [ "1683709939" -lt "1000" ]; then echo "::: INVALID SOURCE_DATE_EPOCH" ; exit 99 ; fi
[ 0:02] [sdist  5/11] WORKDIR /build
[ 0:02] [sdist  4/11] RUN mkdir /build
[ 0:02] [sdist 11/11] RUN ls -l /sdist/*
[ 0:02] [dist 1/8] RUN yum install -y redis
[ 0:02] [dist 2/8] COPY --from=sdist /sdist /sdist
[ 0:02] [package-builder-base 1/3] RUN yum install -y rpm-build rpmdevtools && rpmdev-setuptree
[ 0:23] [package-builder-base 2/3] RUN mkdir -p /dist /build
[ 0:23] [package-builder-base 3/3] WORKDIR /build
[ 0:23] [package-builder  1/11] ADD builder/helpers/ /build/builder/helpers/
[ 0:23] [package-builder  2/11] COPY builder-support/vendor-specs/ builder-support/vendor-specs/
[ 0:24] [package-builder  3/11] RUN BUILDER_CACHE_THIS=1 BUILDER_SOURCE_DATE_FROM_SPEC_MTIME=1 builder/helpers/build-specs.sh builder-support/vendor-specs/*.spec
[ 0:25] 1.474 ::: builder-support/vendor-specs/lua-argparse.spec
[ 0:27] [package-builder  4/11] COPY --from=sdist /sdist /sdist
[ 0:27] [package-builder  5/11] RUN for file in /sdist/* ; do ln -s $file /root/rpmbuild/SOURCES/ ; done && ls /root/rpmbuild/SOURCES/
[ 0:27] [package-builder  6/11] COPY builder-support/specs/ builder-support/specs/
[ 0:27] [package-builder  7/11] RUN builder/helpers/build-specs.sh builder-support/specs/a.spec
[ 0:28] 0.323 ::: builder-support/specs/a.spec
[ 0:28] [package-builder  8/11] RUN builder/helpers/build-specs.sh builder-support/specs/b.spec
[ 0:28] 0.315 ::: builder-support/specs/b.spec
[ 0:29] [package-builder  9/11] RUN cp -R /root/rpmbuild/RPMS/* /dist/
[ 0:29] [package-builder 10/11] RUN rpm -qlp --queryformat '\n# %{RPMTAG_NAME}\n' /dist/*/*.rpm > /dist/rpm-contents-all.txt
[ 0:29] [package-builder 11/11] RUN /build/builder/helpers/generate-yum-provenance.py /dist/rpm-provenance.json
[ 0:30] [dist 3/8] COPY --from=package-builder /dist /dist
[ 0:30] [dist 4/8] RUN yum localinstall -y /dist/*/*.rpm
[ 0:31] [dist 5/8] COPY builder-support/install-tests /build/builder-support/install-tests
[ 0:31] [dist 6/8] WORKDIR /build
[ 0:31] [dist 7/8] RUN builder-support/install-tests/check-installed-files.sh
[ 0:31] [dist 8/8] RUN builder-support/install-tests/test-exec.sh
```
