### PR TITLE
Stop explicitly requiring fakeroot

### DIFF
--- a/helpers/build-debs.sh
+++ b/helpers/build-debs.sh
@@ -77,6 +77,6 @@ EOF
   # allow build to use all available processors
   export DEB_BUILD_OPTIONS='parallel='`nproc`
 
-  fakeroot debian/rules binary || exit 1
+  dpkg-buildpackage -b || exit 1
   popd
 done


### PR DESCRIPTION
On older Debian/Ubuntu it gets installed, and dpkg-buildpackage should use it. On newer versions, we do not need it.

For further reading, see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1041150