### PR TITLE
use platform-python for dnf provenance generation

### DIFF
--- a/helpers/generate-dnf-provenance.py
+++ b/helpers/generate-dnf-provenance.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/libexec/platform-python
 """
 This script uses yum and rpm to generate in-toto material provenance and
 writes the resulting JSON to stdout or to argv[0] if provided.


### PR DESCRIPTION
This PR changes two files. *Either* change fixes the problem (`import dnf` failing in the provenance script), so we need to choose.