### PR TITLE
Add a meson.build modifying script

### DIFF
--- a/helpers/set-meson-build-version.sh
+++ b/helpers/set-meson-build-version.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# TODO: remove this and replace it with the `meson rewrite`
+# tooling pdns-recursor and dnsdist use.
+sed -E -i -e "s/version: run_command.*/version: '${BUILDER_VERSION}',/" meson.build


### PR DESCRIPTION
Same as set-configure-ac-version.sh, but for meson.build.

Only for auth, as the others already use "meson dist" and do not need this. Should be removed when switching to meson dist for auth.